### PR TITLE
2 Updates

### DIFF
--- a/src/optimization/optimization.h
+++ b/src/optimization/optimization.h
@@ -65,6 +65,15 @@ struct OptimizationOptions {
 
 __host__ __device__ inline int JTJSize(const int dimensions) { return ((dimensions*(dimensions+1))>>1); }
 
+__host__ __device__ inline int JTJIndex(const int i, const int j){
+    if(i >= j){
+        return ((i*(i+1))>>1) + j;
+    }
+    else{
+        return ((j*(j+1))>>1) + i;
+    }
+}
+
 struct DataAssociatedPoint {
     int index;
     int dataAssociation;


### PR DESCRIPTION
1. Mirrored memory now skips cudaMalloc/Host and cudaMemcpy when initializing, resizing or copying empty vectors.
2. Added a helper function JTJIndex which given a row and column, looks up the appropriate linear index in a symmetric matrix where only one side is stored.
